### PR TITLE
Fix bug with window / this / global context

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -22,6 +22,7 @@
  */
 
 (function () {
+    'use strict';
     /**
      * @name CSV
      * @namespace
@@ -298,8 +299,8 @@
     (function(name, context, definition) {
             if (typeof module != 'undefined' && module.exports) module.exports = definition();
             else if (typeof define == 'function' && typeof define.amd == 'object') define(definition);
-            else this[name] = definition();
-        }('CSV', this, function()
+            else context[name] = definition();
+        }('CSV', Function('return this')(), function()
             { return CSV; }
         )
     );


### PR DESCRIPTION
It looks like you were assigning `this` to context, assuming that it was `window` (es3) and then not referencing the context. When `this` was null (es5 mode) it barfed.
