### PR TITLE
Parse negative numbers and exponent notation

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -280,7 +280,7 @@
     };
 
     CSV.resolve_type = function (token) {
-        if( token.match(/^\d+(\.\d+)?$/) ){
+        if( token.match(/^[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?$/) ){
             token = parseFloat(token);
         }
         else if( token.match(/^(true|false)$/i) ){

--- a/unit/index.html
+++ b/unit/index.html
@@ -65,6 +65,10 @@
                     CSV.parse("1,.2,3.,4.5,6.7.8"),
                     [[1,'.2','3.',4.5,'6.7.8']] );
 
+            unit.assert("negative numbers, leading + and numbers with exponent",
+                    CSV.parse("-1,+1,1.0e0,1e+2,1E-3"),
+                    [[-1,+1,1,100,0.001]] );
+
             unit.assert("booleans, null, unefined",
                     CSV.parse("1,true,null,false,undefined"),
                     [[1,true,null,false,undefined]] );


### PR DESCRIPTION
needed to parse negative numbers, but thought it would be nice to support all valid floating point numbers.

 `NaN`, `Infinity` and `-Infinity` are not yet supported.