### PR TITLE
feat: take regex column separator

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -81,6 +81,9 @@
      */
     CSV.parse = function (str) {
         var result = CSV.result = [];
+        CSV.COLUMN_SEPARATOR = CSV.COLUMN_SEPARATOR instanceof RegExp ?
+            new RegExp('^' + CSV.COLUMN_SEPARATOR.source) : CSV.COLUMN_SEPARATOR;
+
         CSV.offset = 0;
         CSV.str = str;
         CSV.record_begin();
@@ -174,7 +177,7 @@
                 CSV.token_end();
                 CSV.record_end();
             }
-            else if (c == CSV.COLUMN_SEPARATOR) {
+            else if (CSV.test_regex_separater(str) || CSV.COLUMN_SEPARATOR == c) {
                 CSV.token_end();
             }
             else if( CSV.state == MID_TOKEN ){
@@ -227,6 +230,21 @@
             done()
         };
         return s
+    };
+
+    CSV.test_regex_separater = function(str) {
+        if (!(CSV.COLUMN_SEPARATOR instanceof RegExp)) {
+            return false;
+        }
+
+        var match;
+        str = str.slice(CSV.offset - 1);
+        match = CSV.COLUMN_SEPARATOR.exec(str);
+        if (match) {
+            CSV.offset += match[0].length - 1;
+        }
+
+        return match !== null;
     };
 
     CSV.stream.json = function () {

--- a/unit/index.html
+++ b/unit/index.html
@@ -134,11 +134,21 @@
 
         unit.test("Custom COLUMN_SEPARATOR", function () {
             var originalSeparator = CSV.COLUMN_SEPARATOR;
-            CSV.COLUMN_SEPARATOR = ";"
 
+            CSV.COLUMN_SEPARATOR = ";"
             unit.assert("Using semi-colons",
                     CSV.parse('1;2;3\r\n"foo";22;"bar"'),
                     [[1,2,3],["foo",22,"bar"]] );
+
+            CSV.COLUMN_SEPARATOR = "\t"
+            unit.assert("Using tab characters(tsv)",
+                    CSV.parse('1\t2\t3\r\n"foo"\t22\t"bar"'),
+                    [[1,2,3],["foo",22,"bar"]] );
+
+            CSV.COLUMN_SEPARATOR = /\s+/;
+            unit.assert("Using RegExt /\\s+/",
+                    CSV.parse('1\t2 3\r\n"foo foo"  22\t"bar"'),
+                    [[1,2,3],["foo foo",22,"bar"]] );
 
             CSV.COLUMN_SEPARATOR = originalSeparator;
         });


### PR DESCRIPTION
I have patched it on my ongoing project.
if you see it is worth to take, take it :)
The code accepts **regex delimiters**.

for example, the regex below
```js
CSV.COLUMN_SEPARATOR = /\s+/
```

will works like *white space* separated values

```
col1\tcol2 "col 3"\tcol4
```